### PR TITLE
Fix memory-safety cluster: buffer overflows, null-handle derefs, OOB reads

### DIFF
--- a/libneoradio2/src/hiddevice.cpp
+++ b/libneoradio2/src/hiddevice.cpp
@@ -140,14 +140,23 @@ bool HidDevice::runConnected()
 			{
 				DEBUG_PRINT("ERROR: Not a valid FT260 Report ID! (length too small: %d)", length);
 			}
-			const int report_id_size = temp[1];
+			else
+			{
+				// temp[1] is the device-reported payload length. Clamp it to the
+				// number of bytes actually received (length - 2) so a bad or
+				// oversized value can't read past temp[64] into the rx fifo.
+				int report_id_size = temp[1];
+				const int max_payload = length - 2;
+				if (report_id_size > max_payload)
+					report_id_size = max_payload;
 #ifdef DEBUG_ANNOYING
-			std::stringstream ss2;
-			for (int i=0; i < report_id_size && i < 30; ++i)
-				ss2 << "0x" << std::hex << (int)temp[i+2] << " ";
-			DEBUG_PRINT("hid_read_parsed(): len: %d channel: %d\n\t\tdata: %s", report_id_size, buffer.first, ss2.str().c_str());
+				std::stringstream ss2;
+				for (int i=0; i < report_id_size && i < 30; ++i)
+					ss2 << "0x" << std::hex << (int)temp[i+2] << " ";
+				DEBUG_PRINT("hid_read_parsed(): len: %d channel: %d\n\t\tdata: %s", report_id_size, buffer.first, ss2.str().c_str());
 #endif // DEBUG_ANNOYING
-			FIFO_Push(&buf->rx_fifo, &temp[2], report_id_size);
+				FIFO_Push(&buf->rx_fifo, &temp[2], report_id_size);
+			}
 		}
 		buf->rx_lock.unlock();
 		// TODO Error handling (length == -1)

--- a/libneoradio2/src/libneoradio2.cpp
+++ b/libneoradio2/src/libneoradio2.cpp
@@ -125,13 +125,17 @@ LIBNEORADIO2_API int neoradio2_find(Neoradio2DeviceInfo* devices, unsigned int* 
 	if (!devices || !device_count)
 		return NEORADIO2_FAILURE;
 
+	// Remember the caller's array capacity; never report more than we wrote.
+	const unsigned int max_count = *device_count;
 	auto devs = Device::findAll<neoRADIO2Device>();
 	//memset(devices, 0, sizeof(Neoradio2DeviceInfo)*(*device_count));
-	for (unsigned int i=0; i < devs.size() && i < *device_count; ++i)
+	unsigned int count = 0;
+	for (unsigned int i=0; i < devs.size() && i < max_count; ++i)
 	{
 		devices[i] = devs.at(i)->getDeviceInfo()->di;
+		++count;
 	}
-	*device_count = devs.size();
+	*device_count = count;
 
 	return NEORADIO2_SUCCESS;
 }
@@ -208,6 +212,8 @@ LIBNEORADIO2_API int neoradio2_is_opened(neoradio2_handle* handle, int* is_opene
 	if (!is_opened)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
+	if (!dev)
+		return NEORADIO2_FAILURE;
 	*is_opened = dev->isOpen();
 	return NEORADIO2_SUCCESS;
 }
@@ -252,6 +258,8 @@ LIBNEORADIO2_API int neoradio2_is_closed(neoradio2_handle* handle, int* is_close
 	if (!is_closed)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
+	if (!dev)
+		return NEORADIO2_FAILURE;
 	*is_closed = !dev->isOpen();
 	return NEORADIO2_SUCCESS;
 }
@@ -264,6 +272,8 @@ LIBNEORADIO2_API int neoradio2_is_closed(neoradio2_handle* handle, int* is_close
 LIBNEORADIO2_API int neoradio2_chain_is_identified(neoradio2_handle* handle, int* is_identified)
 {
 	auto dev = _getDevice(*handle);
+	if (!dev)
+		return NEORADIO2_FAILURE;
 	if (!dev->isOpen() && !is_identified)
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
@@ -282,7 +292,7 @@ LIBNEORADIO2_API int neoradio2_chain_is_identified(neoradio2_handle* handle, int
 LIBNEORADIO2_API int neoradio2_chain_identify(neoradio2_handle* handle)
 {
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -304,6 +314,8 @@ LIBNEORADIO2_API int neoradio2_chain_identify(neoradio2_handle* handle)
 LIBNEORADIO2_API int neoradio2_app_is_started(neoradio2_handle* handle, int device, int bank, int* is_started)
 {
 	auto dev = _getDevice(*handle);
+	if (!dev)
+		return NEORADIO2_FAILURE;
 	if (!dev->isOpen() && !is_started)
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
@@ -326,7 +338,7 @@ LIBNEORADIO2_API int neoradio2_app_is_started(neoradio2_handle* handle, int devi
 LIBNEORADIO2_API int neoradio2_app_start(neoradio2_handle* handle, int device, int bank)
 {
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -348,7 +360,7 @@ LIBNEORADIO2_API int neoradio2_app_start(neoradio2_handle* handle, int device, i
 LIBNEORADIO2_API int neoradio2_enter_bootloader(neoradio2_handle* handle, int device, int bank)
 {
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -374,7 +386,7 @@ LIBNEORADIO2_API int neoradio2_get_serial_number(neoradio2_handle* handle, int d
 	if (!serial_number)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -398,7 +410,7 @@ LIBNEORADIO2_API int neoradio2_get_manufacturer_date(neoradio2_handle* handle, i
 	if (!year && !month && !day)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -422,7 +434,7 @@ LIBNEORADIO2_API int neoradio2_get_firmware_version(neoradio2_handle* handle, in
 	if (!major && !minor)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -446,7 +458,7 @@ LIBNEORADIO2_API int neoradio2_get_hardware_revision(neoradio2_handle* handle, i
 	if (!major && !minor)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -472,7 +484,7 @@ LIBNEORADIO2_API int neoradio2_get_device_type(neoradio2_handle* handle, int dev
 	if (!device_type)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -489,7 +501,7 @@ LIBNEORADIO2_API int neoradio2_get_device_type(neoradio2_handle* handle, int dev
 LIBNEORADIO2_API int neoradio2_request_pcbsn(neoradio2_handle* handle, int device, int bank)
 {
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -506,7 +518,7 @@ LIBNEORADIO2_API int neoradio2_get_pcbsn(neoradio2_handle* handle, int device, i
 		return NEORADIO2_FAILURE;
 
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -515,14 +527,19 @@ LIBNEORADIO2_API int neoradio2_get_pcbsn(neoradio2_handle* handle, int device, i
 	std::string temp;
 	bool success = radio_dev->getPCBSN(device, bank, temp) ? NEORADIO2_SUCCESS : NEORADIO2_FAILURE;;
 	memset(pcb_sn, 0, 17);
-	memcpy(pcb_sn, temp.c_str(), 17);
+	// Copy at most 16 chars from the (variable-length) device string and keep
+	// the final byte as the NUL terminator zeroed above.
+	size_t copy_len = temp.size();
+	if (copy_len > 16)
+		copy_len = 16;
+	memcpy(pcb_sn, temp.c_str(), copy_len);
 	return success;
 }
 
 LIBNEORADIO2_API int neoradio2_request_sensor_data(neoradio2_handle* handle, int device, int bank, int enable_cal)
 {
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -538,7 +555,7 @@ LIBNEORADIO2_API int neoradio2_read_sensor_float(neoradio2_handle* handle, int d
 	if (!value)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -557,7 +574,7 @@ LIBNEORADIO2_API int neoradio2_read_sensor_array(neoradio2_handle* handle, int d
 	if (!arr && !arr_size)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -576,7 +593,7 @@ LIBNEORADIO2_API int neoradio2_read_sensor_array(neoradio2_handle* handle, int d
 LIBNEORADIO2_API int neoradio2_write_sensor(neoradio2_handle* handle, int device, int bank, uint8_t * data, int len)
 {
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -591,7 +608,7 @@ LIBNEORADIO2_API int neoradio2_write_sensor(neoradio2_handle* handle, int device
 LIBNEORADIO2_API int neoradio2_write_sensor_successful(neoradio2_handle* handle, int device, int bank)
 {
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -603,7 +620,7 @@ LIBNEORADIO2_API int neoradio2_write_sensor_successful(neoradio2_handle* handle,
 LIBNEORADIO2_API int neoradio2_request_settings(neoradio2_handle* handle, int device, int bank)
 {
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -620,7 +637,7 @@ LIBNEORADIO2_API int neoradio2_read_settings(neoradio2_handle* handle, int devic
 		return NEORADIO2_FAILURE;
 
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -636,7 +653,7 @@ LIBNEORADIO2_API int neoradio2_write_settings(neoradio2_handle* handle, int devi
 	if (!settings)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -652,7 +669,7 @@ LIBNEORADIO2_API int neoradio2_write_settings(neoradio2_handle* handle, int devi
 LIBNEORADIO2_API int neoradio2_write_settings_successful(neoradio2_handle* handle, int device, int bank)
 {
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -666,7 +683,7 @@ LIBNEORADIO2_API int neoradio2_get_chain_count(neoradio2_handle* handle, int* co
 	if (!count)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -684,7 +701,7 @@ LIBNEORADIO2_API int neoradio2_get_chain_count(neoradio2_handle* handle, int* co
 LIBNEORADIO2_API int neoradio2_request_calibration(neoradio2_handle* handle, int device, int bank, neoRADIO2frame_calHeader* header)
 {
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -701,7 +718,7 @@ LIBNEORADIO2_API int neoradio2_read_calibration_array(neoradio2_handle* handle, 
 	if (!arr && !arr_size)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -720,7 +737,7 @@ LIBNEORADIO2_API int neoradio2_read_calibration_array(neoradio2_handle* handle, 
 LIBNEORADIO2_API int neoradio2_request_calibration_points(neoradio2_handle* handle, int device, int bank, neoRADIO2frame_calHeader* header)
 {
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -737,7 +754,7 @@ LIBNEORADIO2_API int neoradio2_read_calibration_points_array(neoradio2_handle* h
 	if (!arr && !arr_size)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -758,7 +775,7 @@ LIBNEORADIO2_API int neoradio2_write_calibration(neoradio2_handle* handle, int d
 	if (!header && !arr && !arr_size)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -776,7 +793,7 @@ LIBNEORADIO2_API int neoradio2_write_calibration(neoradio2_handle* handle, int d
 LIBNEORADIO2_API int neoradio2_write_calibration_successful(neoradio2_handle* handle, int device, int bank)
 {
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -791,7 +808,7 @@ LIBNEORADIO2_API int neoradio2_write_calibration_points(neoradio2_handle* handle
 	if (!header && !arr && !arr_size)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -809,7 +826,7 @@ LIBNEORADIO2_API int neoradio2_write_calibration_points(neoradio2_handle* handle
 LIBNEORADIO2_API int neoradio2_write_calibration_points_successful(neoradio2_handle* handle, int device, int bank)
 {
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -821,7 +838,7 @@ LIBNEORADIO2_API int neoradio2_write_calibration_points_successful(neoradio2_han
 LIBNEORADIO2_API int neoradio2_store_calibration(neoradio2_handle* handle, int device, int bank)
 {
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -838,7 +855,7 @@ LIBNEORADIO2_API int neoradio2_is_calibration_stored(neoradio2_handle* handle, i
 	if (!stored)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -854,7 +871,7 @@ LIBNEORADIO2_API int neoradio2_get_calibration_is_valid(neoradio2_handle* handle
 	if (!is_valid)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -868,7 +885,7 @@ LIBNEORADIO2_API int neoradio2_get_calibration_is_valid(neoradio2_handle* handle
 LIBNEORADIO2_API int neoradio2_clear_calibration(neoradio2_handle* handle, int device, int bank)
 {
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -881,7 +898,7 @@ LIBNEORADIO2_API int neoradio2_clear_calibration(neoradio2_handle* handle, int d
 LIBNEORADIO2_API int neoradio2_request_calibration_info(neoradio2_handle* handle, int device, int bank)
 {
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -897,7 +914,7 @@ LIBNEORADIO2_API int neoradio2_read_calibration_info(neoradio2_handle* handle, i
 	if (!header)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -909,7 +926,7 @@ LIBNEORADIO2_API int neoradio2_read_calibration_info(neoradio2_handle* handle, i
 LIBNEORADIO2_API int neoradio2_toggle_led(neoradio2_handle* handle, int device, int bank, int mode, int led_enables, int ms)
 {
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -923,7 +940,7 @@ LIBNEORADIO2_API int neoradio2_toggle_led(neoradio2_handle* handle, int device, 
 LIBNEORADIO2_API int neoradio2_toggle_led_successful(neoradio2_handle* handle, int device, int bank)
 {
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -937,7 +954,7 @@ LIBNEORADIO2_API int neoradio2_get_status(neoradio2_handle* handle, int device, 
 	if (!status)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -952,7 +969,7 @@ LIBNEORADIO2_API int neoradio2_get_status(neoradio2_handle* handle, int device, 
 LIBNEORADIO2_API int neoradio2_write_default_settings(neoradio2_handle* handle, int device, int bank)
 {
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -967,7 +984,7 @@ LIBNEORADIO2_API int neoradio2_write_default_settings(neoradio2_handle* handle, 
 LIBNEORADIO2_API int neoradio2_request_statistics(neoradio2_handle* handle, int device, int bank)
 {
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)
@@ -984,7 +1001,7 @@ LIBNEORADIO2_API int neoradio2_read_statistics(neoradio2_handle* handle, int dev
 		return NEORADIO2_FAILURE;
 
 	auto dev = _getDevice(*handle);
-	if (!dev->isOpen())
+	if (!dev || !dev->isOpen())
 		return NEORADIO2_FAILURE;
 	auto radio_dev = static_cast<neoRADIO2Device*>(dev.get());
 	if (!radio_dev)

--- a/libneoradio2/src/neoradio2device.cpp
+++ b/libneoradio2/src/neoradio2device.cpp
@@ -730,7 +730,15 @@ bool neoRADIO2Device::writeUartFrame(neoRADIO2frame* frame, DeviceChannel channe
 		DEBUG_PRINT("ERROR: Failed to generate frame checksum!");
 		return false;
 	}
-	uint8_t buffer[64] ={0};
+	// A device payload is at most sizeof(frame->data) bytes; reject anything
+	// larger so the header + data + crc copies below cannot overflow buffer.
+	if (frame->header.len > sizeof(frame->data))
+	{
+		DEBUG_PRINT("ERROR: frame length %d exceeds maximum payload %d!", frame->header.len, (int)sizeof(frame->data));
+		return false;
+	}
+	// header + full data payload + crc
+	uint8_t buffer[sizeof(frame->header) + sizeof(frame->data) + 1] = {0};
 	uint16_t size = sizeof(frame->header)+2+1; // frame + ft260 header + crc
 											   // copy the header into the buffer
 	memcpy(&buffer[0], (uint8_t*)&frame->header, sizeof(frame->header));
@@ -1506,7 +1514,10 @@ bool neoRADIO2Device::writeCalibration(int device, int bank, const neoRADIO2fram
 		0 // crc
 	};
 
-	if (data.size() > sizeof(frame.data))
+	// frame.data holds the cal header followed by the float payload, so the
+	// number of floats is bounded by the remaining space, not sizeof(frame.data).
+	const size_t max_floats = (sizeof(frame.data) - sizeof(header)) / sizeof(float);
+	if (data.size() > max_floats)
 		return false;
 	memcpy(frame.data, &header, sizeof(header));
 	for (unsigned int i=0; i < data.size(); ++i)
@@ -1578,7 +1589,10 @@ bool neoRADIO2Device::writeCalibrationPoints(int device, int bank, const neoRADI
 		},
 		0 // crc
 	};
-	if (data.size() > sizeof(frame.data))
+	// frame.data holds the cal header followed by the float payload, so the
+	// number of floats is bounded by the remaining space, not sizeof(frame.data).
+	const size_t max_floats = (sizeof(frame.data) - sizeof(header)) / sizeof(float);
+	if (data.size() > max_floats)
 		return false;
 	memcpy(frame.data, &header, sizeof(header));
 	for (unsigned int i=0; i < data.size(); ++i)

--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -138,13 +138,22 @@ PYBIND11_MODULE(neoradio2, m) {
 		.def_readwrite("charSize", &neoRADIO2Settings_ChannelName::charSize)
 		//.def_readwrite("chars", &neoRADIO2Settings_ChannelName::chars)
 		.def_property("chars", 
-			[](neoRADIO2Settings_ChannelName& self) 
+			[](neoRADIO2Settings_ChannelName& self)
 			{
-				return std::string((char*)self.chars.u8);
+				// The buffer is not guaranteed to be NUL-terminated; bound the length.
+				const char* p = (const char*)self.chars.u8;
+				size_t n = 0;
+				while (n < sizeof(self.chars.u8) && p[n] != '\0')
+					++n;
+				return std::string(p, n);
 			},
 			[](neoRADIO2Settings_ChannelName& self, std::string value)
 			{
-				memcpy(self.chars.u8, value.c_str(), value.size());
+				// Never copy more than the fixed buffer can hold.
+				size_t copy_len = value.size();
+				if (copy_len > sizeof(self.chars.u8))
+					copy_len = sizeof(self.chars.u8);
+				memcpy(self.chars.u8, value.c_str(), copy_len);
 			});
 
 	// radio2_frame.h
@@ -240,6 +249,9 @@ PYBIND11_MODULE(neoradio2, m) {
         auto res = neoradio2_find(temp, &device_count);
         if (res != NEORADIO2_SUCCESS)
             throw NeoRadio2Exception("neoradio2_find() failed");
+        // Never trust a returned count larger than the array we passed in.
+        if (device_count > size)
+            device_count = size;
         devs.reserve(device_count);
         std::copy(std::begin(temp), std::begin(temp)+device_count, std::back_inserter(devs));
         return devs;
@@ -972,7 +984,7 @@ PYBIND11_MODULE(neoradio2, m) {
 	m.def("read_sensor_array", [](neoradio2_handle& handle, int device, int bank) {
 		py::gil_scoped_release release;
 		int arr[64] = {0};
-		int arr_size = sizeof(arr);
+		int arr_size = sizeof(arr) / sizeof(arr[0]);
 		if (neoradio2_read_sensor_array(&handle, device, bank, arr, &arr_size) != NEORADIO2_SUCCESS)
 			throw NeoRadio2Exception("neoradio2_read_sensor_array() failed");
 		std::vector<int> values;
@@ -1539,7 +1551,7 @@ PYBIND11_MODULE(neoradio2, m) {
 	m.def("read_calibration_array", [](neoradio2_handle& handle, int device, int bank, neoRADIO2frame_calHeader& header) {
         py::gil_scoped_release release;
 		float arr[64] ={0};
-		int arr_size = sizeof(arr);
+		int arr_size = sizeof(arr) / sizeof(arr[0]);
 		if (neoradio2_read_calibration_array(&handle, device, bank, &header, arr, &arr_size) != NEORADIO2_SUCCESS)
 			throw NeoRadio2Exception("neoradio2_read_calibration_array() failed");
 		std::vector<float> values;
@@ -1632,7 +1644,7 @@ PYBIND11_MODULE(neoradio2, m) {
 	m.def("read_calibration_points_array", [](neoradio2_handle& handle, int device, int bank, neoRADIO2frame_calHeader& header) {
         py::gil_scoped_release release;
 		float arr[64] ={0};
-		int arr_size = sizeof(arr);
+		int arr_size = sizeof(arr) / sizeof(arr[0]);
 		if (neoradio2_read_calibration_points_array(&handle, device, bank, &header, arr, &arr_size) != NEORADIO2_SUCCESS)
 			throw NeoRadio2Exception("neoradio2_read_calibration_points_array() failed");
 		std::vector<float> values;


### PR DESCRIPTION
First fix PR from the full codebase review (tracking #51). This tackles the highest-risk cluster — defects reachable from untrusted device input over the wire or from ordinary C / Python API calls. They share fix patterns (bound lengths in element units; null-check `_getDevice`), so they're grouped here.

## Fixes

| Issue | Fix |
|-------|-----|
| #26 | Stack buffer overflows from byte-size vs element-count confusion — `writeUartFrame` buffer sized to hold a maximal frame + `len` guard; `writeCalibration`/`writeCalibrationPoints` bound the float count by remaining space; Python `read_*_array` pass element capacity not `sizeof` |
| #27 | Unbounded `memcpy` in the pybind11 `chars` setter — clamp to buffer size; getter no longer assumes NUL termination |
| #28 | Device-controlled `report_id_size` (`temp[1]`, 0–255) clamped to bytes actually received before `FIFO_Push`; skip push when `length < 2` |
| #31 | Null-handle dereference — every C entry point now guards the null `shared_ptr` from `_getDevice` |
| #38 | `neoradio2_find` no longer reports a count larger than the caller's array; Python binding also caps the copy |
| #44 | `neoradio2_get_pcbsn` copies at most 16 chars from the variable-length string and keeps the terminator |

## Verification

- **Builds clean** with MSVC 2022 (VS 17, C++14): both the core `libneoradio2` static library and the `neoradio2` pybind11 extension. (Pre-existing hidapi `LNK4006` warning is unrelated.)
- **Runtime smoke test** on the built module confirms the behavior change:
  - `is_opened(999999)` (invalid handle) now raises a clean exception instead of segfaulting the interpreter.
  - `s.chars = "A" * 10000` clamps to 64 bytes instead of smashing the heap.
  - `find()` with no hardware returns `[]` cleanly.

## Notes / follow-ups (not in this PR)

- The submodules (`hidapi`, `neoRAD-IO2-FrameDescription`) had to be checked out to build; the sdist packaging issue is tracked separately in #33.
- Thread-safety/lifecycle (#29, #36, #37) and build/packaging (#33, #41, #47, #48) are the next two planned PRs.

Closes #26, #27, #28, #31, #38, #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)
