### PR TITLE
Fix thread-safety and worker-thread lifecycle bugs

### DIFF
--- a/libneoradio2/include/device.h
+++ b/libneoradio2/include/device.h
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <map>
 #include <memory>
+#include <atomic>
 
 #include "config.h"
 #include "libneoradio2common.h"
@@ -153,14 +154,12 @@ protected:
 	}
 
 private:
-	bool mIsRunning;
-	bool mQuit;
+	std::atomic<bool> mIsRunning;
+	std::atomic<bool> mQuit;
 	std::thread* mThread;
 	std::mutex mMutex;
 
-	
-
-	DeviceState mState;
+	std::atomic<DeviceState> mState;
 
 	// this is the actual thread loop that calls run()
 	void start();

--- a/libneoradio2/include/fifo.h
+++ b/libneoradio2/include/fifo.h
@@ -148,6 +148,12 @@ extern "C" {
 #if defined(INLINE_FIFO_PUSH_POP)
 	ics_inline void FIFO_Push(fifo_t* f, const uint8_t* bytes, unsigned int numBytes)
 	{
+		/* Never write more than the free space: overflowing corrupts numItems
+		   (making FIFO_GetFreeSpace underflow) and, for numBytes > maxSz, would
+		   write past the backing buffer. Excess bytes are dropped. */
+		unsigned int freeSpace = FIFO_GetFreeSpace(f);
+		if (numBytes > freeSpace)
+			numBytes = freeSpace;
 		unsigned int copySz = numBytes;
 		if (copySz > (f->maxSz - f->in))
 			copySz = (f->maxSz - f->in);
@@ -162,6 +168,11 @@ extern "C" {
 
 	ics_inline void FIFO_Pop(fifo_t* f, uint8_t* bytes, unsigned int numBytes)
 	{
+		/* Never read more than is available: underflowing corrupts numItems and
+		   reads stale data. Callers requesting more get only what exists. */
+		unsigned int count = FIFO_GetCount(f);
+		if (numBytes > count)
+			numBytes = count;
 		unsigned int copySz = numBytes;
 		if (copySz > (f->maxSz - f->out))
 			copySz = (f->maxSz - f->out);

--- a/libneoradio2/include/hiddevice.h
+++ b/libneoradio2/include/hiddevice.h
@@ -42,7 +42,10 @@ public:
 	virtual ~HidBuffer()
 	{
 		if (handle)
+		{
+			hid_close(handle);
 			handle = NULL;
+		}
 
 		if (tx_buffer)
 		{

--- a/libneoradio2/include/neoradio2device.h
+++ b/libneoradio2/include/neoradio2device.h
@@ -9,6 +9,7 @@
 #include "neoradio2framehandler.h"
 #include "devicecommandhandler.h"
 #include <unordered_map>
+#include <atomic>
 
 #include "radio2_frames.h"
 
@@ -171,12 +172,12 @@ protected:
 	}
 
 private:
-	bool mIsRunning;
-	bool mQuit;
+	std::atomic<bool> mIsRunning;
+	std::atomic<bool> mQuit;
 	std::thread* mThread;
 	std::mutex mMutex;
 
-	int mDeviceCount;
+	std::atomic<int> mDeviceCount;
 
 	void updateDeviceCount(int device_count);
 

--- a/libneoradio2/src/device.cpp
+++ b/libneoradio2/src/device.cpp
@@ -8,8 +8,9 @@ Device::Device()
 {
 	mState = DeviceStateIdle;
 	mQuit = false;
+	mIsRunning = false;
 	mThread = nullptr;
-	
+
 	
 	memset(&mDevInfo.di, 0, sizeof(mDevInfo.di));
 	mDevInfo.is_blocking = 0;
@@ -26,6 +27,10 @@ bool Device::open()
 {
 	if (!isOpen())
 	{
+		// Tear down any previous worker before starting a new one so we never
+		// leak the std::thread object or run two workers on the same device.
+		quit(true);
+		mQuit = false;
 		changeState(DeviceStateConnecting);
 		mThread = new std::thread(&Device::start, this);
 	}
@@ -60,7 +65,7 @@ void Device::start()
 	{
 		auto start_time = std::chrono::high_resolution_clock::now();
 		bool success = false;
-		switch (mState)
+		switch (state())
 		{
 		case DeviceStateIdle:
 			success = runIdle();
@@ -106,18 +111,25 @@ bool Device::quit(bool wait_for_quit)
 	mMutex.unlock();
 	if (mThread)
 	{
-		if (wait_for_quit)
+		if (mThread->joinable())
 		{
-			try
+			// Never delete a joinable std::thread (that calls std::terminate).
+			if (wait_for_quit)
 			{
-				mThread->join();
+				try
+				{
+					mThread->join();
+				}
+				catch(const std::exception& e)
+				{
+					DEBUG_PRINT("%s\n", e.what());
+				}
 			}
-			catch(const std::exception& e)
+			else
 			{
-				DEBUG_PRINT("%s\n", e.what());
+				mThread->detach();
 			}
 		}
-			
 		delete mThread;
 		mThread = nullptr;
 	}

--- a/libneoradio2/src/hiddevice.cpp
+++ b/libneoradio2/src/hiddevice.cpp
@@ -11,6 +11,10 @@ HidDevice::HidDevice()
 
 HidDevice::~HidDevice()
 {
+	// Stop the worker thread before freeing the buffers and HID handles it
+	// touches in runConnected()/runDisconnecting(); otherwise the still-running
+	// loop dereferences freed memory (use-after-free).
+	quit(true);
 	for (auto i : mBuffers)
 	{
 		if (i.second)
@@ -195,6 +199,12 @@ bool HidDevice::runDisconnecting()
 	for (auto& buffer : mBuffers)
 	{
 		auto buf = buffer.second;
+		if (!buf)
+			continue;
+		// Hold both locks so we don't close the handle out from under a
+		// concurrent read()/write()/sendFeatureReport() on another thread.
+		std::lock_guard<std::mutex> tx(buf->tx_lock);
+		std::lock_guard<std::mutex> rx(buf->rx_lock);
 		if (buf->handle != NULL)
 			hid_close(buf->handle);
 		buf->handle = NULL;
@@ -295,6 +305,11 @@ bool HidDevice::sendFeatureReport(uint8_t* buffer, uint16_t* buffer_size, Device
 	std::lock_guard<std::mutex> lock(buf->tx_lock);
 
 	if (*buffer_size > sizeof(temp_buf))
+		return false;
+
+	// The handle may have been closed by runDisconnecting(); don't hand a
+	// NULL handle to hidapi.
+	if (buf->handle == NULL)
 		return false;
 
 	// We need exactly 64 bytes to send the report message

--- a/libneoradio2/src/neoradio2device.cpp
+++ b/libneoradio2/src/neoradio2device.cpp
@@ -95,23 +95,31 @@ neoRADIO2Device::~neoRADIO2Device()
 
 bool neoRADIO2Device::quit(bool wait_for_quit)
 {
-	mMutex.lock();
 	mQuit = true;
-	mMutex.unlock();
-	if (mThread && wait_for_quit)
+	if (mThread)
 	{
-		try
+		if (mThread->joinable())
 		{
-			mThread->join();
+			// Never delete a joinable std::thread (that calls std::terminate).
+			if (wait_for_quit)
+			{
+				try
+				{
+					mThread->join();
+				}
+				catch(const std::exception& e)
+				{
+					DEBUG_PRINT("%s", e.what());
+				}
+			}
+			else
+			{
+				mThread->detach();
+			}
 		}
-		catch(const std::exception& e)
-		{
-			DEBUG_PRINT("%s", e.what());
-		}
+		delete mThread;
+		mThread = nullptr;
 	}
-		
-	delete mThread;
-	mThread = nullptr;
 	return true;
 }
 
@@ -288,7 +296,12 @@ bool neoRADIO2Device::runConnecting()
 		return false;
 	}
 	*/
-	mThread = new std::thread(&neoRADIO2Device::start, this);
+	// Only spawn the frame-processing thread once; a reconnect reuses it.
+	if (!mThread)
+	{
+		mQuit = false;
+		mThread = new std::thread(&neoRADIO2Device::start, this);
+	}
 	DEBUG_PRINT_ANNOYING("Changing state to connected!");
 	changeState(DeviceStateConnected);
 	return success;
@@ -2062,9 +2075,8 @@ std::string neoRADIO2Device::frameToString(neoRADIO2frame& frame, bool is_bitfie
 
 void neoRADIO2Device::updateDeviceCount(int device_count)
 {
-	//mMutex.lock();
+	// mDeviceCount is atomic; this store is safe against concurrent readers.
 	mDeviceCount = device_count;
-	//mMutex.unlock();
 }
 
 uint8_t neoRADIO2Device::crc8_Calc(uint8_t* data, int len)


### PR DESCRIPTION
Second fix PR from the review (tracking #51). Covers the thread-safety / lifecycle cluster in the two-worker-thread device machinery (base `Device` state-machine thread + derived `neoRADIO2Device` frame-processing thread).

## Fixes

| Issue | Fix |
|-------|-----|
| #29 | Use-after-free on teardown — the base worker was joined only in `~Device`, after `~HidDevice` freed the `HidBuffer`s it iterates. Now joined in `~HidDevice` before any buffer/handle is freed. |
| #36 | Data races — `mQuit`/`mState`/`mIsRunning` (base) and `mQuit`/`mIsRunning`/`mDeviceCount` (derived) are now `std::atomic`; the base loop reads state via the synchronized accessor; `updateDeviceCount` is safe again. |
| #37 | Lifecycle — `quit(false)` no longer `delete`s a joinable thread (`std::terminate`); `open()` tears down any prior worker and resets `mQuit` before spawning (no leak, no double-thread, clean reconnect); the frame thread is spawned once and reused; HID handles close deterministically (`~HidBuffer` + locked `runDisconnecting`); `sendFeatureReport` null-checks the handle. |
| #43 | `FIFO_Push`/`FIFO_Pop` clamp to free-space/available-items — an over-full push previously corrupted `numItems` (underflowing `FIFO_GetFreeSpace`) and could write past the buffer. |

## Verification

- **Builds clean** (MSVC 2022): both `libneoradio2` and the `neoradio2` pybind11 module.
- **Lifecycle harness** (standalone C++, no hardware): drives a `neoRADIO2Device` through open/close/destroy, 5× reopen, and 20× rapid construct/destroy churn. All blocks complete, **exit 0, no crash or `std::terminate`**. Before the fixes, the destructor UAF and the joinable-thread `delete` could crash or abort on these paths.

## Notes

- Reconnect (`open` after `close`) now works single-threaded rather than spawning a racing second worker; I couldn't exercise a *successful* connect without hardware, but the no-hardware path (runConnecting fails, threads spin, teardown) is covered by the harness.
- Depends conceptually on nothing from PR #52, but touches the same files — rebased on current `master` (post-#52 merge).

Closes #29, #36, #37, #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)
