### PR TITLE
Fix correctness bugs: NULL derefs, bit-math, guards, heap overflow

### DIFF
--- a/libneoradio2/src/hiddevice.cpp
+++ b/libneoradio2/src/hiddevice.cpp
@@ -55,7 +55,6 @@ Devices HidDevice::_findAll()
 		//hdi->serial_number
 		//auto hid_dev = new HidDevice;
 		auto hid_dev = std::make_shared<HidDevice>();
-		devs.push_back(hid_dev);
 		auto di = hid_dev->getDeviceInfo();
 		if (hdi->product_string)
 		{
@@ -74,14 +73,14 @@ Devices HidDevice::_findAll()
 			hid_dev->addPath(CHANNEL_0, hdi->path);
 			if (hdi->next)
 				hid_dev->addPath(CHANNEL_1, hdi->next->path);
-			hdi = hdi->next->next;
+			hdi = hdi->next ? hdi->next->next : NULL;
 		}
 		else if (interface_number == 1)
 		{
 			if (hdi->next)
 				hid_dev->addPath(CHANNEL_0, hdi->next->path);
 			hid_dev->addPath(CHANNEL_1, hdi->path);
-			hdi = hdi->next->next;
+			hdi = hdi->next ? hdi->next->next : NULL;
 		}
 		else
 			hdi = hdi->next;

--- a/libneoradio2/src/libneoradio2.cpp
+++ b/libneoradio2/src/libneoradio2.cpp
@@ -49,7 +49,7 @@ std::shared_ptr<Device> _createNewDevice(neoradio2_handle* handle, Neoradio2Devi
 	DEBUG_PRINT("creating New Device: %s %s", device->name, device->serial_str);
 	std::lock_guard<std::mutex> lock(_lock);
 	static neoradio2_handle counter = 0;
-	if (!device && !handle)
+	if (!device || !handle)
 		return nullptr;
 	for (auto& i : _device_map)
 	{
@@ -407,7 +407,7 @@ LIBNEORADIO2_API int neoradio2_get_serial_number(neoradio2_handle* handle, int d
 //! @return NEORADIO2_SUCCESS if successful or NEORADIO2_FAILURE on failure. Returns NEORADIO2_ERR_WBLOCK in non-blocking mode
 LIBNEORADIO2_API int neoradio2_get_manufacturer_date(neoradio2_handle* handle, int device, int bank, int* year, int* month, int* day)
 {
-	if (!year && !month && !day)
+	if (!year || !month || !day)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
 	if (!dev || !dev->isOpen())
@@ -431,7 +431,7 @@ LIBNEORADIO2_API int neoradio2_get_manufacturer_date(neoradio2_handle* handle, i
 //! @return NEORADIO2_SUCCESS if successful or NEORADIO2_FAILURE on failure. Returns NEORADIO2_ERR_WBLOCK in non-blocking mode
 LIBNEORADIO2_API int neoradio2_get_firmware_version(neoradio2_handle* handle, int device, int bank, int* major, int* minor)
 {
-	if (!major && !minor)
+	if (!major || !minor)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
 	if (!dev || !dev->isOpen())
@@ -455,7 +455,7 @@ LIBNEORADIO2_API int neoradio2_get_firmware_version(neoradio2_handle* handle, in
 //! @return NEORADIO2_SUCCESS if successful or NEORADIO2_FAILURE on failure. Returns NEORADIO2_ERR_WBLOCK in non-blocking mode
 LIBNEORADIO2_API int neoradio2_get_hardware_revision(neoradio2_handle* handle, int device, int bank, int* major, int* minor)
 {
-	if (!major && !minor)
+	if (!major || !minor)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
 	if (!dev || !dev->isOpen())
@@ -571,7 +571,7 @@ LIBNEORADIO2_API int neoradio2_read_sensor_float(neoradio2_handle* handle, int d
 
 LIBNEORADIO2_API int neoradio2_read_sensor_array(neoradio2_handle* handle, int device, int bank, int* arr, int* arr_size)
 {
-	if (!arr && !arr_size)
+	if (!arr || !arr_size)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
 	if (!dev || !dev->isOpen())
@@ -715,7 +715,7 @@ LIBNEORADIO2_API int neoradio2_request_calibration(neoradio2_handle* handle, int
 
 LIBNEORADIO2_API int neoradio2_read_calibration_array(neoradio2_handle* handle, int device, int bank, neoRADIO2frame_calHeader* header, float* arr, int* arr_size)
 {
-	if (!arr && !arr_size)
+	if (!arr || !arr_size)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
 	if (!dev || !dev->isOpen())
@@ -751,7 +751,7 @@ LIBNEORADIO2_API int neoradio2_request_calibration_points(neoradio2_handle* hand
 
 LIBNEORADIO2_API int neoradio2_read_calibration_points_array(neoradio2_handle* handle, int device, int bank, neoRADIO2frame_calHeader* header, float* arr, int* arr_size)
 {
-	if (!arr && !arr_size)
+	if (!arr || !arr_size)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
 	if (!dev || !dev->isOpen())
@@ -772,7 +772,7 @@ LIBNEORADIO2_API int neoradio2_read_calibration_points_array(neoradio2_handle* h
 
 LIBNEORADIO2_API int neoradio2_write_calibration(neoradio2_handle* handle, int device, int bank, neoRADIO2frame_calHeader* header, float* arr, int arr_size)
 {
-	if (!header && !arr && !arr_size)
+	if (!header || !arr || !arr_size)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
 	if (!dev || !dev->isOpen())
@@ -805,7 +805,7 @@ LIBNEORADIO2_API int neoradio2_write_calibration_successful(neoradio2_handle* ha
 
 LIBNEORADIO2_API int neoradio2_write_calibration_points(neoradio2_handle* handle, int device, int bank, neoRADIO2frame_calHeader* header, float* arr, int arr_size)
 {
-	if (!header && !arr && !arr_size)
+	if (!header || !arr || !arr_size)
 		return NEORADIO2_FAILURE;
 	auto dev = _getDevice(*handle);
 	if (!dev || !dev->isOpen())

--- a/libneoradio2/src/neoradio2device.cpp
+++ b/libneoradio2/src/neoradio2device.cpp
@@ -162,14 +162,14 @@ Devices neoRADIO2Device::_findAll()
 			device->addPath(CHANNEL_0, hdi->path);
 			if (hdi->next)
 				device->addPath(CHANNEL_1, hdi->next->path);
-			hdi = hdi->next->next;
+			hdi = hdi->next ? hdi->next->next : NULL;
 		}
 		else if (interface_number == 1)
 		{
 			if (hdi->next)
 				device->addPath(CHANNEL_0, hdi->next->path);
 			device->addPath(CHANNEL_1, hdi->path);
-			hdi = hdi->next->next;
+			hdi = hdi->next ? hdi->next->next : NULL;
 		}
 		else
 			hdi = hdi->next;
@@ -669,9 +669,25 @@ bool neoRADIO2Device::processFrameReadSettings()
 	data.resize(getSettingsSize());
 
 	// Push the partial data into the real vector.
-	const auto offset = NEORADIO2_SETTINGS_PARTSIZE * part.part;
+	const size_t offset = NEORADIO2_SETTINGS_PARTSIZE * part.part;
 
-	std::copy(&part.data[0], &part.data[frame->header.len-1], data.begin() + offset);
+	// header.len counts the part byte plus the payload; the payload is len-1
+	// bytes. Bound both the offset and the copy length to the settings buffer
+	// so a malformed frame (e.g. part index at the tail, or an oversized len)
+	// can't write past data.end().
+	size_t copy_len = (frame->header.len > 0) ? (size_t)(frame->header.len - 1) : 0;
+	if (offset >= data.size())
+	{
+		mDCH.updateCommand(&frame->header, COMMAND_STATE_ERROR, mLastframe.isBitField());
+		DEBUG_PRINT("ERROR: settings part offset %zu is past the settings buffer (%zu)", offset, data.size());
+		return false;
+	}
+	if (copy_len > sizeof(part.data))
+		copy_len = sizeof(part.data);
+	if (offset + copy_len > data.size())
+		copy_len = data.size() - offset;
+
+	std::copy(&part.data[0], &part.data[copy_len], data.begin() + offset);
 	// Update the data with the new partial
 	mDCH.updateExtraData(&frame->header, data, mLastframe.isBitField());
 
@@ -1055,9 +1071,9 @@ bool neoRADIO2Device::requestPCBSN(int device, int bank, std::chrono::millisecon
 	// This command is only available in application code
 	// isApplicationStarted isn't a bitmask
 	for (int d=0; d < 8; ++d)
-		if ((d << 1) & device)
+		if ((1 << d) & device)
 			for (int b=0; b < 8; ++b)
-				if ((b << 1) & bank)
+				if ((1 << b) & bank)
 					if (!isApplicationStarted(d, b, 0s))
 						return false;
 
@@ -1093,9 +1109,9 @@ bool neoRADIO2Device::getPCBSN(int device, int bank, std::string& pcbsn)
 	// This command is only available in application code
 	// isApplicationStarted isn't a bitmask
 	for (int d=0; d < 8; ++d)
-		if ((d << 1) & device)
+		if ((1 << d) & device)
 			for (int b=0; b < 8; ++b)
-				if ((b << 1) & bank)
+				if ((1 << b) & bank)
 					if (!isApplicationStarted(d, b, 0s))
 						return false;
 	pcbsn.clear();
@@ -1113,9 +1129,9 @@ bool neoRADIO2Device::requestSensorData(int device, int bank, int enable_cal, st
 	// This command is only available in application code
 	// isApplicationStarted isn't a bitmask
 	for (int d=0; d < 8; ++d)
-		if ((d << 1) & device)
+		if ((1 << d) & device)
 			for (int b=0; b < 8; ++b)
-				if ((b << 1) & bank)
+				if ((1 << b) & bank)
 					if (!isApplicationStarted(d, b, 0s))
 						return false;
 
@@ -1166,9 +1182,9 @@ bool neoRADIO2Device::writeSensorData(int device, int bank, uint8_t * data, int 
 	// This command is only available in application code
 	// isApplicationStarted isn't a bitmask
 	for (int d = 0; d < 8; ++d)
-		if ((d << 1) & device)
+		if ((1 << d) & device)
 			for (int b = 0; b < 8; ++b)
-				if ((b << 1) & bank)
+				if ((1 << b) & bank)
 					if (!isApplicationStarted(d, b, 0s))
 						return false;
 
@@ -1207,9 +1223,9 @@ bool neoRADIO2Device::writeSensorDataSuccessful(int device, int bank)
 	// This command is only available in application code
 	// isApplicationStarted isn't a bitmask
 	for (int d = 0; d < 8; ++d)
-		if ((d << 1) & device)
+		if ((1 << d) & device)
 			for (int b = 0; b < 8; ++b)
-				if ((b << 1) & bank)
+				if ((1 << b) & bank)
 					if (!isApplicationStarted(d, b, 0s))
 						return false;
 
@@ -1242,9 +1258,9 @@ bool neoRADIO2Device::requestSettings(int device, int bank, std::chrono::millise
 	// This command is only available in application code
 	// isApplicationStarted isn't a bitmask
 	for (int d=0; d < 8; ++d)
-		if ((d << 1) & device)
+		if ((1 << d) & device)
 			for (int b=0; b < 8; ++b)
-				if ((b << 1) & bank)
+				if ((1 << b) & bank)
 					if (!isApplicationStarted(d, b, 0s))
 						return false;
 
@@ -1297,9 +1313,9 @@ bool neoRADIO2Device::writeSettings(int device, int bank, neoRADIO2_settings& se
 	// This command is only available in application code
 	// isApplicationStarted isn't a bitmask
 	for (int d=0; d < 8; ++d)
-		if ((d << 1) & device)
+		if ((1 << d) & device)
 			for (int b=0; b < 8; ++b)
-				if ((b << 1) & bank)
+				if ((1 << b) & bank)
 					if (!isApplicationStarted(d, b, 0s))
 						return false;
 
@@ -1365,9 +1381,9 @@ bool neoRADIO2Device::writeSettingsSuccessful(int device, int bank)
 	// This command is only available in application code
 	// isApplicationStarted isn't a bitmask
 	for (int d = 0; d < 8; ++d)
-		if ((d << 1) & device)
+		if ((1 << d) & device)
 			for (int b = 0; b < 8; ++b)
-				if ((b << 1) & bank)
+				if ((1 << b) & bank)
 					if (!isApplicationStarted(d, b, 0s))
 						return false;
 
@@ -1393,9 +1409,9 @@ bool neoRADIO2Device::requestCalibration(int device, int bank, const neoRADIO2fr
 	// This command is only available in application code
 	// isApplicationStarted isn't a bitmask
 	for (int d=0; d < 8; ++d)
-		if ((d << 1) & device)
+		if ((1 << d) & device)
 			for (int b=0; b < 8; ++b)
-				if ((b << 1) & bank)
+				if ((1 << b) & bank)
 					if (!isApplicationStarted(d, b, 0s))
 						return false;
 
@@ -1450,9 +1466,9 @@ bool neoRADIO2Device::requestCalibrationPoints(int device, int bank, const neoRA
 	// This command is only available in application code
 	// isApplicationStarted isn't a bitmask
 	for (int d=0; d < 8; ++d)
-		if ((d << 1) & device)
+		if ((1 << d) & device)
 			for (int b=0; b < 8; ++b)
-				if ((b << 1) & bank)
+				if ((1 << b) & bank)
 					if (!isApplicationStarted(d, b, 0s))
 						return false;
 
@@ -1507,9 +1523,9 @@ bool neoRADIO2Device::writeCalibration(int device, int bank, const neoRADIO2fram
 	// This command is only available in application code
 	// isApplicationStarted isn't a bitmask
 	for (int d=0; d < 8; ++d)
-		if ((d << 1) & device)
+		if ((1 << d) & device)
 			for (int b=0; b < 8; ++b)
-				if ((b << 1) & bank)
+				if ((1 << b) & bank)
 					if (!isApplicationStarted(d, b, 0s))
 						return false;
 
@@ -1554,9 +1570,9 @@ bool neoRADIO2Device::writeCalibrationSuccessful(int device, int bank)
 	// This command is only available in application code
 	// isApplicationStarted isn't a bitmask
 	for (int d = 0; d < 8; ++d)
-		if ((d << 1) & device)
+		if ((1 << d) & device)
 			for (int b = 0; b < 8; ++b)
-				if ((b << 1) & bank)
+				if ((1 << b) & bank)
 					if (!isApplicationStarted(d, b, 0s))
 						return false;
 
@@ -1583,9 +1599,9 @@ bool neoRADIO2Device::writeCalibrationPoints(int device, int bank, const neoRADI
 	// This command is only available in application code
 	// isApplicationStarted isn't a bitmask
 	for (int d=0; d < 8; ++d)
-		if ((d << 1) & device)
+		if ((1 << d) & device)
 			for (int b=0; b < 8; ++b)
-				if ((b << 1) & bank)
+				if ((1 << b) & bank)
 					if (!isApplicationStarted(d, b, 0s))
 						return false;
 
@@ -1630,9 +1646,9 @@ bool neoRADIO2Device::writeCalibrationPointsSuccessful(int device, int bank)
 	// This command is only available in application code
 	// isApplicationStarted isn't a bitmask
 	for (int d = 0; d < 8; ++d)
-		if ((d << 1) & device)
+		if ((1 << d) & device)
 			for (int b = 0; b < 8; ++b)
-				if ((b << 1) & bank)
+				if ((1 << b) & bank)
 					if (!isApplicationStarted(d, b, 0s))
 						return false;
 
@@ -1658,9 +1674,9 @@ bool neoRADIO2Device::requestStoreCalibration(int device, int bank, std::chrono:
 	// This command is only available in application code
 	// isApplicationStarted isn't a bitmask
 	for (int d=0; d < 8; ++d)
-		if ((d << 1) & device)
+		if ((1 << d) & device)
 			for (int b=0; b < 8; ++b)
-				if ((b << 1) & bank)
+				if ((1 << b) & bank)
 					if (!isApplicationStarted(d, b, 0s))
 						return false;
 
@@ -1708,9 +1724,9 @@ bool neoRADIO2Device::requestCalibrationInfo(int device, int bank, std::chrono::
 	// This command is only available in application code
 	// isApplicationStarted isn't a bitmask
 	for (int d=0; d < 8; ++d)
-		if ((d << 1) & device)
+		if ((1 << d) & device)
 			for (int b=0; b < 8; ++b)
-				if ((b << 1) & bank)
+				if ((1 << b) & bank)
 					if (!isApplicationStarted(d, b, 0s))
 						return false;
 
@@ -1756,9 +1772,9 @@ bool neoRADIO2Device::clearCalibration(int device, int bank, std::chrono::millis
 	// This command is only available in application code
 	// isApplicationStarted isn't a bitmask
 	for (int d = 0; d < 8; ++d)
-		if ((d << 1) & device)
+		if ((1 << d) & device)
 			for (int b = 0; b < 8; ++b)
-				if ((b << 1) & bank)
+				if ((1 << b) & bank)
 					if (!isApplicationStarted(d, b, 0s))
 						return false;
 
@@ -1845,9 +1861,9 @@ bool neoRADIO2Device::writeDefaultSettings(int device, int bank, std::chrono::mi
 	// This command is only available in application code
 	// isApplicationStarted isn't a bitmask
 	for (int d = 0; d < 8; ++d)
-		if ((d << 1) & device)
+		if ((1 << d) & device)
 			for (int b = 0; b < 8; ++b)
-				if ((b << 1) & bank)
+				if ((1 << b) & bank)
 					if (!isApplicationStarted(d, b, 0s))
 						return false;
 

--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -278,15 +278,22 @@ PYBIND11_MODULE(neoradio2, m) {
     
     m.def("open", [](Neoradio2DeviceInfo* device) {
 		py::gil_scoped_release release;
-		neoradio2_handle handle;
+		// Initialize to an invalid handle so we never return (or have
+		// neoradio2_open read) an uninitialized value.
+		neoradio2_handle handle = -1;
 		auto result = neoradio2_open(&handle, device);
-		if (!neoradio2_is_blocking() && result == NEORADIO2_ERR_WBLOCK)
+		if (neoradio2_is_blocking())
 		{
-			//throw NeoRadio2ExceptionWouldBlock("neoradio2_open() would block");
-			return handle;
+			if (result != NEORADIO2_SUCCESS)
+				throw NeoRadio2Exception("neoradio2_open() failed");
 		}
-		else if (neoradio2_is_blocking() && result != NEORADIO2_SUCCESS)
-			throw NeoRadio2Exception("neoradio2_open() failed");
+		else
+		{
+			// Non-blocking: WBLOCK means the open is in progress; any other
+			// non-success result is a real failure, not a valid handle.
+			if (result != NEORADIO2_SUCCESS && result != NEORADIO2_ERR_WBLOCK)
+				throw NeoRadio2Exception("neoradio2_open() failed");
+		}
 		return handle;
 		}, R"pbdoc(
 		open(device)
@@ -1012,7 +1019,9 @@ PYBIND11_MODULE(neoradio2, m) {
 			TODO
 	)pbdoc");
 	m.def("write_sensor", [](neoradio2_handle& handle, int device, int bank, int mask, std::vector<uint8_t> data) {
-		//py::gil_scoped_release release;
+		// data is already copied from Python above; safe to drop the GIL for the
+		// (potentially blocking) write.
+		py::gil_scoped_release release;
 		data.insert(data.begin(), mask);
 		auto result = neoradio2_write_sensor(&handle, device, bank, data.data(), data.size());
 		if (!neoradio2_is_blocking() && result == NEORADIO2_ERR_WBLOCK)


### PR DESCRIPTION
Third fix PR from the review (tracking #51) — a batch of independent correctness defects.

## Fixes

| Issue | Fix |
|-------|-----|
| #30 | `_findAll` (both `HidDevice` and `neoRADIO2Device`) advanced the HID list with `hdi->next->next` without checking `hdi->next` — NULL deref on a single-interface device at the end of enumeration. Guarded. |
| #40 | `HidDevice::_findAll` pushed each device twice (aliased `shared_ptr`); now pushed once after paths are assigned. |
| #32 | `processFrameReadSettings` could write 4 bytes past the 220-byte settings vector (max-size part at the tail index). Offset and copy length are now bounded to `data.size()`, and `header.len == 0` no longer underflows the source index. |
| #34 | The app-started precondition used `(d<<1)`/`(b<<1)` instead of `(1<<d)`/`(1<<b)` — device 0 was never checked and the mask was wrong for the rest. Fixed all 18 nested loops. |
| #35 | `&&` null-guards that bail only when *all* out-params are null, then dereference each → `||`, across 8 functions. Also fixed the same class in `_createNewDevice`. |
| #39 | Python `open()` returned an uninitialized `handle` on a non-blocking failure (and `neoradio2_open` read it via `_getDevice`, UB). Initialize to an invalid handle; throw on any genuine failure. |
| #46 | Python `write_sensor()` held the GIL through the blocking C call; now releases it. |

## Verification

- **Builds clean** (MSVC 2022): both `libneoradio2` and the `neoradio2` module.
- **Smoke test**: `find()` enumeration returns `[]` (exercises the `_findAll` fix), a GIL-released `write_sensor` on a worker thread raises cleanly and the thread joins (no deadlock), and the handle guards still raise.

## Not in this PR

- **#45** (C++ exceptions escaping the `extern "C"` boundary) is deliberately deferred. It's a mechanical `try/catch` wrap of ~50 exported functions and is much easier to review as its own PR — I'll send it next.
- A note on #34: `bank` is a documented bitmask; `device` is iterated as a bitmask in the same loops, so `(1<<d)` matches intent. For a plain `device` *index* of 0 the loop still runs zero iterations (same as before), so no behavior change for the common `device=0` call; the fix corrects true bitmask usage and the never-checked-bit-0 case.

Closes #30, #32, #34, #35, #39, #40, #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)
