### PR TITLE
Fix debug builds broken by atomic mState

### DIFF
--- a/libneoradio2/include/device.h
+++ b/libneoradio2/include/device.h
@@ -135,7 +135,9 @@ protected:
 	void changeState(DeviceState state)
 	{
 		std::lock_guard<std::mutex> lock(mMutex);
-		DEBUG_PRINT("State: old: %d, new: %d", mState, state);
+		// mState is atomic; load it to a plain enum before passing to the
+		// variadic DEBUG_PRINT (an atomic can't be passed to a vararg).
+		DEBUG_PRINT("State: old: %d, new: %d", (int)mState.load(), (int)state);
 		mState = state;
 	}
 	DeviceState state()
@@ -143,10 +145,10 @@ protected:
 		std::lock_guard<std::mutex> lock(mMutex);
 #ifdef DEBUG_ANNOYING
 		// Report every time we change
-		static auto last_state = mState;
+		static DeviceState last_state = mState;
 		if (mState != last_state)
 		{
-			DEBUG_PRINT("State: %d", mState);
+			DEBUG_PRINT("State: %d", (int)mState.load());
 			last_state = mState;
 		}
 #endif // DEBUG_ANNOYING


### PR DESCRIPTION
Follow-up fix found while diagnosing a chain-enumeration question with debug logging enabled.

Making `Device::mState` a `std::atomic` (in #53) silently broke any build with `ENABLE_DEBUG_PRINT` or `DEBUG_ANNOYING` defined:

- `DEBUG_PRINT("... %d ...", mState, ...)` passes a `std::atomic` to a variadic `fprintf` → MSVC C4839 + C2280.
- `static auto last_state = mState;` deduces `std::atomic<DeviceState>` and copy-constructs it → deleted copy ctor.

Release/CI builds never define these flags, so it wasn't caught. Fixed by loading the atomic to a plain enum (`(int)mState.load()`, `static DeviceState last_state = mState`).

**Verified:** a Python module built with both `ENABLE_DEBUG_PRINT` and `ENABLE_DEBUG_PRINT_ANNOYING` enabled now compiles (it didn't before this change), and release builds are unaffected since these lines only compile under the debug flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
