### PR TITLE
Add PyPI publish job (release on version tags)

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -43,3 +43,27 @@ jobs:
             ./wheelhouse/*.whl
             ./wheelhouse/*.tar.gz
           if-no-files-found: error
+
+  deploy_pypi:
+    name: Deploy PyPI
+    runs-on: ubuntu-latest
+    needs: build_wheels
+    # Only publish for version tags (e.g. v1.4.0), never on branch pushes/PRs.
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Collect all built wheels and the sdist
+        uses: actions/download-artifact@v4
+        with:
+          pattern: neoradio2-*
+          merge-multiple: true
+          path: ./wheelhouse/
+
+      - name: Publish to PyPI
+        run: |
+          python -m pip install --upgrade twine
+          twine check ./wheelhouse/*
+          twine upload -u __token__ -p "${{ secrets.PYPI_TOKEN }}" --verbose ./wheelhouse/*


### PR DESCRIPTION
Automates PyPI publishing, matching the `python_ics` setup you pointed me at (token + twine, tag-gated).

## What it adds

A `deploy_pypi` job in `wheels.yml` that:
- runs only when a `v*` tag is pushed (`if: startsWith(github.ref, 'refs/tags/v')`) — branch pushes and PRs still just build, never publish;
- `needs: build_wheels`, so it waits for the full Linux/macOS/Windows × CPython 3.9–3.14 matrix + sdist;
- downloads all the `neoradio2-*` artifacts (wheels + sdist), runs `twine check`, and `twine upload`s them with `secrets.PYPI_TOKEN`.

## One-time setup on your side

The repo needs a **`PYPI_TOKEN`** secret (a PyPI API token scoped to the `neoradio2` project): *Settings → Secrets and variables → Actions → New repository secret*. `python_ics` already uses this exact secret name.

## Publishing v1.4.0 after this merges

The `v1.4.0` tag I created points at a commit that predates this job, so it won't publish on its own. Once this is merged (and `PYPI_TOKEN` is set), I'll re-point `v1.4.0` at the new `master` HEAD so the tag build runs the publish job — or you can, by deleting and re-creating the tag/release. Every future `vX.Y.Z` tag then auto-publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
