### PR TITLE
Wake blocking waiters via condition variable (partial #62)

### DIFF
--- a/libneoradio2/include/devicecommandhandler.h
+++ b/libneoradio2/include/devicecommandhandler.h
@@ -9,6 +9,8 @@
 #include <tuple>
 #include <vector>
 #include <mutex>
+#include <condition_variable>
+#include <chrono>
 #include <string>
 #include <cassert>
 
@@ -35,6 +37,7 @@ public:
 			std::lock_guard<std::mutex> lock(mSof[sof][device][bank][cmd].lock);
 			mSof[sof][device][bank][cmd].state = cmd_state;
 			DEBUG_PRINT_ANNOYING("updateCommand(): %d -- [0x%x][0x%x][0x%x][0x%x]", cmd_state, sof, device, bank, cmd);
+			signalStateChange();
 			return true;
 		}
 		for (auto d = 0; d < 8; ++d)
@@ -51,6 +54,7 @@ public:
 			}
 		}
 		DEBUG_PRINT_ANNOYING("updateCommand(): %d -- [0x%x][0x%x][0x%x][0x%x] bitfield", cmd_state, sof, device, bank, cmd);
+		signalStateChange();
 		return true;
 	}
 
@@ -76,6 +80,7 @@ public:
 				mSof[sof][device][bank][cmd].state = cmd_state;
 				DEBUG_PRINT_ANNOYING("updateCommand(): %d -- [0x%x][0x%x][0x%x][0x%x]", cmd_state, sof, device, bank, cmd);
 			}
+			signalStateChange();
 			return true;
 		}
 		for (auto d = 0; d < 8; ++d)
@@ -95,6 +100,7 @@ public:
 			}
 		}
 		DEBUG_PRINT_ANNOYING("updateCommand(): %d -- [0x%x][0x%x][0x%x][0x%x] bitfield", cmd_state, sof, device, bank, cmd);
+		signalStateChange();
 		return true;
 	}
 
@@ -265,15 +271,24 @@ public:
 	bool isStateSet(int sof, int device, int bank, int cmd, T cmd_state, bool bitfield, std::chrono::milliseconds timeout)
 	{
 		using namespace std::chrono;
-		auto start_time = std::chrono::high_resolution_clock::now();
-		do
+		auto start_time = high_resolution_clock::now();
+		for (;;)
 		{
 			if (isStateSet(sof, device, bank, cmd, cmd_state, bitfield))
 				return true;
-			else
-				std::this_thread::sleep_for(1ms);
-		} while ((std::chrono::high_resolution_clock::now() - start_time) <= timeout);
-		return false;
+			auto elapsed = high_resolution_clock::now() - start_time;
+			if (elapsed > timeout)
+				return false;
+			// Wake as soon as a command state changes (signalStateChange), so
+			// a completed command returns near the wire round-trip instead of
+			// waiting for a fixed poll tick. The wait is capped so a
+			// notification missed between the check above and the wait below
+			// only costs a couple of milliseconds, never the full timeout.
+			auto remaining = duration_cast<milliseconds>(timeout - elapsed);
+			auto wait = remaining < milliseconds(2) ? remaining : milliseconds(2);
+			std::unique_lock<std::mutex> lk(mCondMutex);
+			mCond.wait_for(lk, wait);
+		}
 	}
 
 	bool isStateSet(int sof, int device, int bank, int cmd, T cmd_state, bool bitfield)
@@ -374,6 +389,16 @@ private:
 
 private:
 	std::mutex mLock;
+
+	// Signalled whenever a command state changes so blocking waiters
+	// (isStateSet with a timeout) wake immediately instead of sleep-polling.
+	std::condition_variable mCond;
+	std::mutex mCondMutex;
+
+	void signalStateChange()
+	{
+		mCond.notify_all();
+	}
 };
 
 #endif // __DEVICE_COMMAND_HANDLER_H__


### PR DESCRIPTION
Addresses part of #62 (blocking-mode measurement latency).

## Change

The blocking `DeviceCommandHandler::isStateSet(..., timeout)` wait sleep-polled every 1 ms, and each poll re-locked `mLock` up to 64× (bitfield path) — contending with the frame-processor thread that needs `mLock` to advance the command to its terminal state. This replaces that with a **condition-variable wake**: `updateCommand`/`updateCommandIf` signal on any state change, and the blocking wait sleeps on the CV (capped at 2 ms so a missed notification costs a couple ms, never the full timeout). Thread-safety from #53 is preserved — the CV uses its own mutex and doesn't reorder the existing locks.

## Measured (neoRAD-IO2-TC, real sensor read, A/B on the same hardware)

| | median | min |
|---|---|---|
| Before (sleep-poll) | ~60 ms | ~35 ms |
| After (CV wake) | **~46 ms** | ~27 ms |

~24% faster, plus lower CPU (no more 1 ms poll spinning `mLock`).

## Honest scope note

This does **not** get to the 5–20 ms goal in #62, and my initial hypothesis (that sleep-polling was the main cost) was only partly right — a clean A/B on real reads showed the **dominant latency is the device ADC + USB/FT260 round-trip** (~30–46 ms floor for a TC), not software. So #62 stays open: the CV wake is a genuine improvement, but reaching 5–20 ms per *fresh* value isn't possible for a single blocking read; batching active banks into one round-trip (amortizing the ~40 ms) is the real lever for throughput.

Refs #62 (leaving it open for the round-trip investigation).
